### PR TITLE
Fix Content-Type in Prometheus Speedtest Exporter to text/plain

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,11 @@ use std::time::Duration;
 use crate::config::Config;
 use crate::metrics::{register, register_int, FloatGauge, IntGauge};
 use crate::speedtest::run_speedtest;
-use axum::response::IntoResponse;
+use axum::{
+    response::{IntoResponse, Response},
+    http::{StatusCode, header},
+    body::Body,
+};
 use axum::routing::get;
 use axum::Router;
 use clap::Parser;
@@ -137,7 +141,11 @@ async fn handle_metrics() -> impl IntoResponse {
     let metric_families = prometheus::gather();
     let mut buffer = Vec::new();
     encoder.encode(&metric_families, &mut buffer).unwrap();
-    (axum::http::StatusCode::OK, buffer)
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, "text/plain")
+        .body(Body::from(buffer))
+        .unwrap()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The Prometheus Speedtest Exporter was returning metrics with the `Content-Type` header set to "application/octet-stream," but Prometheus expects the metrics to be returned with "text/plain" for proper ingestion.

![Captura de Tela 2025-01-08 às 18 36 09](https://github.com/user-attachments/assets/f73e8106-a2a2-480f-87ff-cbd4510fb556)

This PR adds the Content-Type header with the value "text/plain." After this adjustment, Prometheus is able to consume the metrics correctly.

![Captura de Tela 2025-01-08 às 18 36 19](https://github.com/user-attachments/assets/431565e4-ce1d-4887-a71b-43eb28cd1306)


